### PR TITLE
Fix dashboard layout: icon clipping, table stripes, plot alignment

### DIFF
--- a/_extensions/kth-quarto/kth-content.css
+++ b/_extensions/kth-quarto/kth-content.css
@@ -111,6 +111,21 @@ main table th.numeric {
   font-variant-numeric: tabular-nums;
 }
 
+/* ─── Quarto Dashboard card tables ───────────────────────────────────────── */
+/* kableExtra injects table-striped regardless of bootstrap_options in the   */
+/* Quarto render context. Override via the Bootstrap 5 CSS custom property   */
+/* rather than fighting the class attribute.                                  */
+/* Borders are removed the same way: transparent border-color beats the      */
+/* table-bordered/default border rules without requiring table-borderless.   */
+.quarto-dashboard .card-body table {
+  --bs-table-striped-bg: transparent;
+  --bs-table-striped-color: inherit;
+}
+.quarto-dashboard .card-body table th,
+.quarto-dashboard .card-body table td {
+  border-color: transparent;
+}
+
 /* ─── Quarto Dashboard value boxes ───────────────────────────────────────── */
 /* KTH brand hex colors passed via #| color: are all dark; force white text   */
 /* so contrast meets WCAG AA regardless of bslib's auto-calculation           */
@@ -120,11 +135,28 @@ main table th.numeric {
 }
 
 /* Fix icon clipping in dashboard value boxes                                 */
-/* quarto-dashboard.scss sets .bi::before { vertical-align: 1em } which      */
-/* raises the glyph ~54px above baseline, clipping against overflow:hidden   */
-/* on .value-box-grid. Reset to baseline so centering works correctly.        */
-.bslib-value-box .value-box-showcase .bi::before {
+/* quarto-dashboard.scss compiles to:                                         */
+/*   .quarto-dashboard .bslib-value-box .value-box-showcase .bi::before      */
+/*   { vertical-align: 1em }   ← specificity (0,0,4,1)                       */
+/* Our selector must match that 4-class chain to win the cascade.             */
+/* The vertical-align shift raises the glyph by ~1em (40-60px at clamp       */
+/* sizes), overflowing the value-box-grid's overflow:hidden boundary.         */
+/* overflow:visible on the grid prevents clipping in both left-center and     */
+/* vertical (narrow container query) reflow modes.                            */
+.quarto-dashboard .bslib-value-box .value-box-showcase .bi::before {
   vertical-align: 0;
+}
+.quarto-dashboard .bslib-value-box .value-box-grid {
+  overflow: visible;
+}
+
+/* Prevent long value-box titles from wrapping to a second line, which       */
+/* shifts the icon upward past the card top in left-center layout mode.      */
+/* Truncate with ellipsis rather than clipping hard.                         */
+.quarto-dashboard .bslib-value-box .value-box-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* ─── Quarto Dashboard navbar ─────────────────────────────────────────────── */

--- a/dashboard.qmd
+++ b/dashboard.qmd
@@ -76,35 +76,32 @@ depts <- data.frame(
 #| label: pub-chart
 #| title: "Publications"
 
-pubs_long <- tidyr::pivot_longer(pubs, c(total, oa),
-  names_to = "type", values_to = "n")
-pubs_long$type <- factor(pubs_long$type,
-  levels = c("total", "oa"),
-  labels = c("Total", "Open access"))
+colors <- c("Total" = "#004791", "Open access" = "#3f824e")
 
-p <- ggplot(pubs_long, aes(year, n, colour = type, group = type)) +
-  geom_line(linewidth = 1.2) +
-  geom_point(size = 2.5) +
-  scale_colour_manual(
-    values = c("Total" = "#004791", "Open access" = "#3f824e")) +
-  scale_x_continuous(breaks = 2015:2024) +
-  labs(x = NULL, y = NULL, colour = NULL) +
-  theme_minimal(base_family = "Figtree") +
-  theme(
-    plot.background  = element_blank(),
-    panel.grid.minor = element_blank(),
-    legend.position  = "bottom",
-    axis.text        = element_text(colour = "#646464")
-  )
-
-ggplotly(p) |>
+plot_ly() |>
+  add_trace(
+    x = pubs$year, y = pubs$total,
+    type = "scatter", mode = "lines+markers", name = "Total",
+    line   = list(color = colors[["Total"]], width = 2),
+    marker = list(color = colors[["Total"]], size = 7)
+  ) |>
+  add_trace(
+    x = pubs$year, y = pubs$oa,
+    type = "scatter", mode = "lines+markers", name = "Open access",
+    line   = list(color = colors[["Open access"]], width = 2),
+    marker = list(color = colors[["Open access"]], size = 7)
+  ) |>
   layout(
+    xaxis         = list(tickvals = 2015:2024, tickcolor = "#646464",
+                         tickfont = list(color = "#646464")),
+    yaxis         = list(side = "right", automargin = TRUE,
+                         tickcolor = "#646464",
+                         tickfont = list(color = "#646464")),
     legend        = list(orientation = "h", x = 0, y = -0.15),
     font          = list(family = "Figtree", color = "#212121"),
     paper_bgcolor = "rgba(0,0,0,0)",
     plot_bgcolor  = "rgba(0,0,0,0)",
-    margin        = list(l = 0, r = 40, t = 10, b = 0),
-    yaxis         = list(side = "right", automargin = TRUE)
+    margin        = list(l = 0, r = 0, t = 10, b = 0)
   ) |>
   config(displayModeBar = FALSE)
 ```
@@ -113,10 +110,13 @@ ggplotly(p) |>
 
 ```{r}
 #| label: dept-table
+#| title: "Publications by department"
 
-knitr::kable(depts, format = "html",
-  table.attr = 'class="table table-hover table-sm"') |>
-  kableExtra::kable_styling(full_width = TRUE) |>
+knitr::kable(depts, format = "html") |>
+  kableExtra::kable_styling(
+    full_width       = TRUE,
+    bootstrap_options = c("hover", "sm", "borderless")
+  ) |>
   kableExtra::column_spec(3, bold = TRUE, color = "#004791") |>
   kableExtra::column_spec(4, color = "#3f824e")
 ```


### PR DESCRIPTION
## Summary

- **Value box icon clipping** — `quarto-dashboard.scss` compiles a `.quarto-dashboard .bslib-value-box .value-box-showcase .bi::before { vertical-align: 1em }` rule (4-class specificity) that raises Bootstrap Icon glyphs by ~40–60px, clipping them against `overflow: hidden` on `.value-box-grid`. The fix adds a matching-specificity override resetting `vertical-align` to 0 and sets `overflow: visible` on the grid so icons remain unclipped in both the default left-center layout and the narrow-container vertical reflow mode.

- **Value box title wrapping at intermediate widths** — at ~300px per card (4 cards on a ~1200px viewport) bslib's container query switches value boxes to a stacked vertical layout. Long titles such as "Publications (2024)" that wrap to two lines grow the text row, pushing the icon above the card boundary. Fixed with `white-space: nowrap; text-overflow: ellipsis` on `.value-box-title`.

- **Table stripes** — `kableExtra` injects `table-striped` on the `<table>` element unconditionally in the Quarto render context regardless of the `bootstrap_options` argument. Suppressed via the Bootstrap 5 CSS custom property `--bs-table-striped-bg: transparent` scoped to `.quarto-dashboard .card-body table`, which is more reliable than trying to control the injected class attribute.

- **Table borders** — cell borders removed by setting `border-color: transparent` on `th`/`td` within dashboard card body tables, scoped to avoid affecting prose tables elsewhere.

- **Plot left-margin offset** — replaced `ggplotly()` with native `plot_ly() + add_trace()`. `ggplotly()` bakes `xaxis.domain` (e.g. `[0.15, 1.0]`) from ggplot2's internal grob measurements; post-hoc `layout(margin = list(l = 0))` moves the paper edge but cannot change the domain, leaving a persistent ~94px left offset in the SVG bglayer rect. Native `plot_ly()` starts with `domain = [0, 1]` and fully respects `margin = list(l = 0)`.

- **Table card title** — added `#| title: "Publications by department"` to the `dept-table` chunk. `###` section headings are layout primitives in Quarto Dashboard and are not rendered as visible card headers for pure code-output cells; `#| title:` is the correct mechanism.

## Test plan

- [x] Open `dashboard.html` at full width — value box icons fully visible, no clipping
- [x] Resize to ~1100px — icons remain visible through the container-query reflow; long titles truncate with ellipsis rather than wrapping
- [x] Resize to mobile width — vertical stacked layout still shows icons correctly
- [x] Table shows no alternating row shading and no cell borders
- [x] Plot left edge, legend, and card left edge are flush (no ~94px gap)
- [x] Both chart card ("Publications") and table card ("Publications by department") show card header titles